### PR TITLE
Hardened X server detection

### DIFF
--- a/tdm
+++ b/tdm
@@ -71,7 +71,7 @@ clear
 (basename $(tty)|grep -q tty) || fallback "Invalid tty"
 
 # X started, exit
-w -oush | grep -E ' :[0-9]+' > /dev/null && fallback 'X started.'
+[[ $(ls -1 /tmp/.X11-unix | wc -l) -gt 0 ]] && fallback 'X started.'
 
 # build confdir
 if [ ! -d "${CONFDIR}" ]; then

--- a/tdm
+++ b/tdm
@@ -71,7 +71,7 @@ clear
 (basename $(tty)|grep -q tty) || fallback "Invalid tty"
 
 # X started, exit
-pgrep X>/dev/null&&fallback 'X started.'
+w -oush | grep -E ' :[0-9]+' > /dev/null && fallback 'X started.'
 
 # build confdir
 if [ ! -d "${CONFDIR}" ]; then


### PR DESCRIPTION
It happened that the method to detect running X servers failed for me. It wrongfully detected VirtualBox instances and may detect other programs as well (pgrep X).
I replaced this with the method described here:
http://unix.stackexchange.com/questions/17255/is-there-a-command-to-list-all-open-displays-on-a-machine