### PR TITLE
Fix tdm relaunch after killing X.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v1.2.4] 2017-10-06
+
+### Changed
+
+* tdm: Bugfix preventing tdm from relaunching after starting X
+
 ## [v1.2.3] 2017-10-05
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # News
 
+## [v1.2.4] 2017-10-06
+
+### Changed
+
+* Bugfix preventing tdm from relaunching after starting X
+
 ## [v1.2.3] 2017-08-06
 
 ### Changed

--- a/tdm
+++ b/tdm
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with tdm.  If not, see <http://www.gnu.org/licenses/>.
 
-VERSION=1.2.3
+VERSION=1.2.4
 
 # directory settings
 CONFDIR="$HOME/.tdm"
@@ -135,7 +135,8 @@ if [ $TOTAL -eq 0 ]; then
 fi
 
 tdm_curses(){
-	sid=$(dialog ${DEFOPT} --menu "TDM ${VERSION}" 0 0 0 ${prglist[@]})
+	dialog --stdout ${DEFOPT} --menu "TDM ${VERSION}" 0 0 0 ${prglist[@]}
+	sid=$?
 	[ -n "$sid" ]||fallback "Falling back to shell."
 }
 

--- a/tdm
+++ b/tdm
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with tdm.  If not, see <http://www.gnu.org/licenses/>.
 
-VERSION=1.2.4
+VERSION=1.2.3
 
 # directory settings
 CONFDIR="$HOME/.tdm"
@@ -106,7 +106,7 @@ if [ -d ${SESSIONS} ]; then
 			xsessions[$XID]="${script}"
 			NAME=$(basename ${script})
 			prglist=(${prglist[@]} ${XID} ${NAME})
-			if [ "${NAME}" == ${DEFAULTWM} ]; then
+			if [[ "${NAME}" == ${DEFAULTWM} ]]; then
 				DEFOPT="--default-item ${XID}"
 			fi
 			let XID=$(($XID+1))
@@ -135,8 +135,10 @@ if [ $TOTAL -eq 0 ]; then
 fi
 
 tdm_curses(){
-	dialog --stdout ${DEFOPT} --menu "TDM ${VERSION}" 0 0 0 ${prglist[@]}
-	sid=$?
+	tempfile="/tmp/tdm_$$"
+	trap "rm -f ${tempfile}" 0 1 2 3 6 9 14 15
+	dialog ${DEFOPT} --menu "TDM ${VERSION}" 0 0 0 ${prglist[@]} 2>${tempfile}
+	sid=$(cat ${tempfile})
 	[ -n "$sid" ]||fallback "Falling back to shell."
 }
 


### PR DESCRIPTION
Buggy behavior was noted in the following example scenario:

`tdm` is run in `/dev/tty1`.  When the line above is run, the command substitution above captures `stdout` in its subshell.  `X` is then started.  Once `X` is killed and `tdm` is run again in `/dev/tty1`, `stdout` is still locked to the subshell making it so that a new instance of `dialog` cannot write to it.

The bug was narrowed down to [dopsi/console-tdm/tdm:138](https://github.com/dopsi/console-tdm/blob/469a8118225c20f478886db2026e564d2f32cf66/tdm#L138):

```bash
sid=$(dialog --stdout ${DEFOPT} --menu "TDM ${VERSION}" 0 0 0 ${prglist[@]})
```


This bugfix makes it so that no command substitution is used, therefore not launching a subshell, thus keeping `stdout` open for another instance of `dialog`.