### PR TITLE
Fix disable_xrunning_check flag not working

### DIFF
--- a/tdm
+++ b/tdm
@@ -92,7 +92,7 @@ fi
 if [[ -n "$1" ]] && [[ "$1" == "--disable-xrunning-check" ]] ; then
     disable_xrunning_check=true
 else
-    disable_xrunning_check=false
+    disable_xrunning_check=""
 fi
 
 clear


### PR DESCRIPTION
The README.md stipulates that 

> If you want to allow multiple X sessions, you must use the --disable-xrunning-check option.

This feature is not working due to  the ` [[ ! $disable_xrunning_check ]] ` check in `tdm`. The logical not operator (!)  returns true whatever the variable `disable_xrunning_check` is set to. Removing the `disable_xrunning_check=false` case fixes the issue. Changing the check to ` [[ 
 $disable_xrunning_check = true ]] ` would also work.