### PR TITLE
Add possibility to pass args to startx

### DIFF
--- a/tdm
+++ b/tdm
@@ -65,6 +65,7 @@ CONFDIR="$(load_confdir_path)"
 SESSIONS=${CONFDIR}/sessions
 EXTRA=${CONFDIR}/extra
 SAVELAST=1
+STARTXARGS=
 
 if [ "$CONFDIR" == "$HOME/.tdm" ] ; then
     echo "Following tdm v1.3.0, the configuration files should be moved to '${XDG_CONFIG_HOME:-$HOME/.config}/tdm' in order to become XDG compliant"
@@ -204,11 +205,11 @@ elif [[ (-n $sid) && ($sid -lt $XID) && ($sid -ge 0) ]]; then
     else
         ln -sf "${xsessions[${sid}]}" "/tmp/tdmdefault"
     fi
-    startx
+    startx ${STARTXARGS}
 else
     echo "Unknown value, load default."
     if [ -x "${CONFDIR}/default" ]; then
-        startx
+        startx ${STARTXARGS}
     else
         fallback "Session not defined, fallback."
     fi

--- a/tdminit
+++ b/tdminit
@@ -24,5 +24,8 @@
 # Uncomment to show linux logo
 #linux_logo -L classic
 
+# Args passed along when calling startx
+#STARTXARGS=
+
 # Uncomment to start X without selecting a session
 #exec startx


### PR DESCRIPTION
TDM acts like a wrapper around startx.

This PR adds a new option in tdminit: STARTXARGS
As its name describes, it can be used to pass args to `startx`.
This can be useful when one wants to be in compliance with XDG base directories spec and reference a file different from .xinitrc ($XDG_CONFIG_HOME/X11/xinitrc for example).